### PR TITLE
feat: support groups of reviewers per repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,28 @@ Create a `gh-rr.yml` file in your home directory for configuring groups of
 reviewers:
 
 ```yaml
-# this is a map of repositories to a list of GitHub usernames
+# this is a map of repositories to groups of GitHub usernames
 repositories:
   g-rath/my-awesome-app:
-    - g-rath
-    - octocat
+    default:
+      - g-rath
+      - octocat
+    infra:
+      - octodog
+      - octopus
   g-rath/dotfiles:
-    - g-rath
+    default:
+      - g-rath
 ```
 
 Then start requesting reviewers on your pull requests:
 
 ```shell
 gh rr g-rath/my-awesome-app 123
+```
+
+You can specify specific groups using `--from`:
+
+```shell
+gh rr --from infra g-rath/my-awesome-app 123
 ```

--- a/__snapshots__/main_test.snap
+++ b/__snapshots__/main_test.snap
@@ -8,6 +8,17 @@ please create <tempdir>/gh-rr.yml to configure your repositories
 
 ---
 
+[Test_run/explicit_group - 1]
+adding the following as reviewers to https://github.com/octocat/hello-world/pull/123
+  - octodog
+  - octopus
+
+---
+
+[Test_run/explicit_group - 2]
+
+---
+
 [Test_run/fulsome_case - 1]
 adding the following as reviewers to https://github.com/octocat/hello-world/pull/123
   - octocat
@@ -15,6 +26,15 @@ adding the following as reviewers to https://github.com/octocat/hello-world/pull
 ---
 
 [Test_run/fulsome_case - 2]
+
+---
+
+[Test_run/group_does_not_exist_in_config - 1]
+
+---
+
+[Test_run/group_does_not_exist_in_config - 2]
+octocat/hello-world does not have a group named does-not-exist
 
 ---
 


### PR DESCRIPTION
This adds support for defining "groups" of reviewers for a repository, since it's common to have different groups of people working on aspects of the same codebase - for example, a platforms or infrastructure team who you want to review pull requests that change Terraform configuration.

A group can be specified using `--from`, with `default` being the default group; currently this group must always be defined even if it's the only group but later I'll look into supporting being able to omit that.

Resolves #1