### PR TITLE
feat: make pull request argument optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,19 @@ repositories:
 Then start requesting reviewers on your pull requests:
 
 ```shell
+# will infer the pull request to target based on the current branch
+gh rr g-rath/my-awesome-app
+
+# will infer the pull request based on the named branch
+gh rr g-rath/my-awesome-app my-feature
+
+# will target the specific pull request
 gh rr g-rath/my-awesome-app 123
 ```
+
+Under the hood this extension uses
+[`gh pr edit`](https://cli.github.com/manual/gh_pr_edit) to add reviewers, with
+the second argument being provided as that commands first argument.
 
 You can specify specific groups using `--from`:
 

--- a/__snapshots__/main_test.snap
+++ b/__snapshots__/main_test.snap
@@ -48,21 +48,12 @@ yaml: unmarshal errors:
 
 ---
 
-[Test_run/pull_request_is_not_required - 1]
-
----
-
-[Test_run/pull_request_is_not_required - 2]
-please create <tempdir>/gh-rr.yml to configure your repositories
-
----
-
 [Test_run/pull_request_must_be_a_number_(when_provided) - 1]
 
 ---
 
 [Test_run/pull_request_must_be_a_number_(when_provided) - 2]
-second argument must be pull request number
+please create <tempdir>/gh-rr.yml to configure your repositories
 
 ---
 
@@ -99,5 +90,14 @@ first argument must be repository in <owner>/<repository> format
 
 [Test_run/repository_should_not_be_a_url - 2]
 repository should be in the format of <owner>/<repository>
+
+---
+
+[Test_run/target_is_not_required - 1]
+
+---
+
+[Test_run/target_is_not_required - 2]
+please create <tempdir>/gh-rr.yml to configure your repositories
 
 ---

--- a/__snapshots__/main_test.snap
+++ b/__snapshots__/main_test.snap
@@ -9,7 +9,7 @@ please create <tempdir>/gh-rr.yml to configure your repositories
 ---
 
 [Test_run/explicit_group - 1]
-adding the following as reviewers to https://github.com/octocat/hello-world/pull/123
+would have used `gh pr edit` to request reviews from:
   - octodog
   - octopus
 
@@ -20,7 +20,7 @@ adding the following as reviewers to https://github.com/octocat/hello-world/pull
 ---
 
 [Test_run/fulsome_case - 1]
-adding the following as reviewers to https://github.com/octocat/hello-world/pull/123
+would have used `gh pr edit` to request reviews from:
   - octocat
 
 ---
@@ -48,20 +48,20 @@ yaml: unmarshal errors:
 
 ---
 
-[Test_run/pull_request_must_be_a_number - 1]
+[Test_run/pull_request_is_not_required - 1]
 
 ---
 
-[Test_run/pull_request_must_be_a_number - 2]
-second argument must be pull request number
+[Test_run/pull_request_is_not_required - 2]
+please create <tempdir>/gh-rr.yml to configure your repositories
 
 ---
 
-[Test_run/pull_request_must_be_provided_as_the_second_argument - 1]
+[Test_run/pull_request_must_be_a_number_(when_provided) - 1]
 
 ---
 
-[Test_run/pull_request_must_be_provided_as_the_second_argument - 2]
+[Test_run/pull_request_must_be_a_number_(when_provided) - 2]
 second argument must be pull request number
 
 ---

--- a/__snapshots__/main_test.snap
+++ b/__snapshots__/main_test.snap
@@ -48,15 +48,6 @@ yaml: unmarshal errors:
 
 ---
 
-[Test_run/pull_request_must_be_a_number_(when_provided) - 1]
-
----
-
-[Test_run/pull_request_must_be_a_number_(when_provided) - 2]
-please create <tempdir>/gh-rr.yml to configure your repositories
-
----
-
 [Test_run/repository_does_not_exist_in_config - 1]
 
 ---
@@ -90,6 +81,15 @@ first argument must be repository in <owner>/<repository> format
 
 [Test_run/repository_should_not_be_a_url - 2]
 repository should be in the format of <owner>/<repository>
+
+---
+
+[Test_run/target_does_not_have_to_be_a_number - 1]
+
+---
+
+[Test_run/target_does_not_have_to_be_a_number - 2]
+please create <tempdir>/gh-rr.yml to configure your repositories
 
 ---
 

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/cli/go-gh/v2"
@@ -64,12 +63,8 @@ func determineReviewers(config Config, repository string, group string) ([]strin
 	return reviewers, nil
 }
 
-func buildPullRequestURL(repository string, pr string) string {
-	return fmt.Sprintf("https://github.com/%s/pull/%s", repository, pr)
-}
-
-func buildAddReviewersArgs(repository string, pr string, reviewers []string) []string {
-	args := []string{"pr", "edit", pr, "--repo", repository}
+func buildAddReviewersArgs(repository string, target string, reviewers []string) []string {
+	args := []string{"pr", "edit", target, "--repo", repository}
 
 	for _, reviewer := range reviewers {
 		args = append(args, "--add-reviewer", reviewer)
@@ -113,20 +108,6 @@ func validateRepositoryArg(stderr io.Writer, repository string) bool {
 	return true
 }
 
-func validatePullRequestArg(stderr io.Writer, pr string) bool {
-	if pr == "" {
-		return true
-	}
-
-	if _, err := strconv.Atoi(pr); err != nil {
-		fmt.Fprintln(stderr, "second argument must be pull request number")
-
-		return false
-	}
-
-	return true
-}
-
 func run(args []string, stdout, stderr io.Writer) int {
 	cli := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
@@ -138,9 +119,9 @@ func run(args []string, stdout, stderr io.Writer) int {
 	_ = cli.Parse(args)
 
 	repository := cli.Arg(0)
-	pr := cli.Arg(1)
+	target := cli.Arg(1)
 
-	if !validateRepositoryArg(stderr, repository) || !validatePullRequestArg(stderr, pr) {
+	if !validateRepositoryArg(stderr, repository) {
 		return 1
 	}
 
@@ -174,7 +155,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	if *isDryRun {
 		fmt.Fprintf(stdout, "would have used `gh pr edit` to request reviews from:\n")
 	} else {
-		url, errMsg := addReviewers(repository, pr, reviewers)
+		url, errMsg := addReviewers(repository, target, reviewers)
 
 		if errMsg != "" {
 			fmt.Fprintf(stdout, "\ncould not add reviewers: %s\n", strings.TrimSpace(errMsg))

--- a/main.go
+++ b/main.go
@@ -73,8 +73,8 @@ func buildAddReviewersArgs(repository string, target string, reviewers []string)
 	return args
 }
 
-func addReviewers(repository string, pr string, reviewers []string) (string, string) {
-	stdout, stderr, _ := gh.Exec(buildAddReviewersArgs(repository, pr, reviewers)...)
+func addReviewers(repository string, target string, reviewers []string) (string, string) {
+	stdout, stderr, _ := gh.Exec(buildAddReviewersArgs(repository, target, reviewers)...)
 
 	return strings.TrimSpace(stdout.String()), stderr.String()
 }

--- a/main_test.go
+++ b/main_test.go
@@ -94,55 +94,6 @@ func Test_buildAddReviewersArgs(t *testing.T) {
 	}
 }
 
-func Test_buildPullRequestURL(t *testing.T) {
-	t.Parallel()
-
-	type args struct {
-		repository string
-		pr         string
-	}
-	tests := []struct {
-		name string
-		args args
-		want string
-	}{
-		{
-			name: "with everything empty",
-			args: args{
-				repository: "",
-				pr:         "",
-			},
-			want: "https://github.com//pull/",
-		},
-		{
-			name: "with a repository",
-			args: args{
-				repository: "octocat/hello-world",
-				pr:         "",
-			},
-			want: "https://github.com/octocat/hello-world/pull/",
-		},
-		{
-			name: "with everything provided",
-			args: args{
-				repository: "octocat/hello-world",
-				pr:         "123",
-			},
-			want: "https://github.com/octocat/hello-world/pull/123",
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			if got := buildPullRequestURL(tt.args.repository, tt.args.pr); got != tt.want {
-				t.Errorf("buildPullRequestURL() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func Test_determineReviewers(t *testing.T) {
 	t.Parallel()
 
@@ -396,7 +347,7 @@ func Test_run(t *testing.T) {
 			exit: 1,
 		},
 		{
-			name: "pull request is not required",
+			name: "target is not required",
 			args: args{
 				args:   []string{"octocat/hello-world"},
 				config: "",

--- a/main_test.go
+++ b/main_test.go
@@ -388,17 +388,17 @@ func Test_run(t *testing.T) {
 			exit: 1,
 		},
 		{
-			name: "pull request must be provided as the second argument",
+			name: "pull request must be a number (when provided)",
 			args: args{
-				args:   []string{"octocat/hello-world"},
+				args:   []string{"octocat/hello-world", "abc"},
 				config: "",
 			},
 			exit: 1,
 		},
 		{
-			name: "pull request must be a number",
+			name: "pull request is not required",
 			args: args{
-				args:   []string{"octocat/hello-world", "abc"},
+				args:   []string{"octocat/hello-world"},
 				config: "",
 			},
 			exit: 1,

--- a/main_test.go
+++ b/main_test.go
@@ -21,7 +21,7 @@ func Test_buildAddReviewersArgs(t *testing.T) {
 
 	type args struct {
 		repository string
-		pr         string
+		target     string
 		reviewers  []string
 	}
 	tests := []struct {
@@ -33,7 +33,7 @@ func Test_buildAddReviewersArgs(t *testing.T) {
 			name: "with everything empty",
 			args: args{
 				repository: "",
-				pr:         "",
+				target:     "",
 				reviewers:  nil,
 			},
 			want: []string{
@@ -45,7 +45,7 @@ func Test_buildAddReviewersArgs(t *testing.T) {
 			name: "with no reviewers",
 			args: args{
 				repository: "octocat/hello-world",
-				pr:         "123",
+				target:     "123",
 				reviewers:  nil,
 			},
 			want: []string{
@@ -57,7 +57,7 @@ func Test_buildAddReviewersArgs(t *testing.T) {
 			name: "with one reviewer",
 			args: args{
 				repository: "octocat/hello-world",
-				pr:         "123",
+				target:     "123",
 				reviewers:  []string{"octocat"},
 			},
 			want: []string{
@@ -70,7 +70,7 @@ func Test_buildAddReviewersArgs(t *testing.T) {
 			name: "with some reviewers",
 			args: args{
 				repository: "octocat/hello-world",
-				pr:         "123",
+				target:     "123",
 				reviewers:  []string{"octocat", "octodog", "octopus"},
 			},
 			want: []string{
@@ -87,7 +87,7 @@ func Test_buildAddReviewersArgs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := buildAddReviewersArgs(tt.args.repository, tt.args.pr, tt.args.reviewers); !reflect.DeepEqual(got, tt.want) {
+			if got := buildAddReviewersArgs(tt.args.repository, tt.args.target, tt.args.reviewers); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("buildAddReviewersArgs() = %v, want %v", got, tt.want)
 			}
 		})
@@ -339,17 +339,17 @@ func Test_run(t *testing.T) {
 			exit: 1,
 		},
 		{
-			name: "pull request must be a number (when provided)",
+			name: "target is not required",
 			args: args{
-				args:   []string{"octocat/hello-world", "abc"},
+				args:   []string{"octocat/hello-world"},
 				config: "",
 			},
 			exit: 1,
 		},
 		{
-			name: "target is not required",
+			name: "target does not have to be a number",
 			args: args{
-				args:   []string{"octocat/hello-world"},
+				args:   []string{"octocat/hello-world", "abc"},
 				config: "",
 			},
 			exit: 1,


### PR DESCRIPTION
In making the second argument optional, we're able to take advantage of the inference supported by `gh pr edit` so users can now pass a pull request number, branch, url, or just omit it entirely.

This does mean that we're now reliant on the output from `gh pr edit` to always return the pull request url but I think it'll be fine at least for now.

Resolves #5