### PR TITLE
refactor: call `gh.Exec` using a function argument to make it easier to cover in tests

### DIFF
--- a/__snapshots__/main_test.snap
+++ b/__snapshots__/main_test.snap
@@ -8,8 +8,18 @@ please create <tempdir>/gh-rr.yml to configure your repositories
 
 ---
 
-[Test_run/explicit_group - 1]
+[Test_run/dry_run - 1]
 would have used `gh pr edit` to request reviews from:
+  - octocat
+
+---
+
+[Test_run/dry_run - 2]
+
+---
+
+[Test_run/explicit_group - 1]
+requested reviews on https://github.com/octocat/hello-world from:
   - octodog
   - octopus
 
@@ -20,7 +30,7 @@ would have used `gh pr edit` to request reviews from:
 ---
 
 [Test_run/fulsome_case - 1]
-would have used `gh pr edit` to request reviews from:
+requested reviews on https://github.com/octocat/hello-world from:
   - octocat
 
 ---

--- a/__snapshots__/main_test.snap
+++ b/__snapshots__/main_test.snap
@@ -29,6 +29,20 @@ requested reviews on https://github.com/octocat/hello-world from:
 
 ---
 
+[Test_run/explicit_group - 3]
+[
+ "pr",
+ "edit",
+ "123",
+ "--repo",
+ "octocat/hello-world",
+ "--add-reviewer",
+ "octodog",
+ "--add-reviewer",
+ "octopus"
+]
+---
+
 [Test_run/fulsome_case - 1]
 requested reviews on https://github.com/octocat/hello-world from:
   - octocat
@@ -37,6 +51,18 @@ requested reviews on https://github.com/octocat/hello-world from:
 
 [Test_run/fulsome_case - 2]
 
+---
+
+[Test_run/fulsome_case - 3]
+[
+ "pr",
+ "edit",
+ "123",
+ "--repo",
+ "octocat/hello-world",
+ "--add-reviewer",
+ "octocat"
+]
 ---
 
 [Test_run/group_does_not_exist_in_config - 1]
@@ -120,4 +146,16 @@ could not add reviewers: no pull requests found for branch "update-readme"
 
 [Test_run/when_ghExec_fails - 2]
 
+---
+
+[Test_run/when_ghExec_fails - 3]
+[
+ "pr",
+ "edit",
+ "",
+ "--repo",
+ "octocat/hello-world",
+ "--add-reviewer",
+ "octocat"
+]
 ---

--- a/__snapshots__/main_test.snap
+++ b/__snapshots__/main_test.snap
@@ -111,3 +111,13 @@ please create <tempdir>/gh-rr.yml to configure your repositories
 please create <tempdir>/gh-rr.yml to configure your repositories
 
 ---
+
+[Test_run/when_ghExec_fails - 1]
+
+could not add reviewers: no pull requests found for branch "update-readme"
+
+---
+
+[Test_run/when_ghExec_fails - 2]
+
+---

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -146,3 +146,17 @@ func writeTempConfigFile(t *testing.T, content string) string {
 
 	return f.Name()
 }
+
+func expectNoCallToGh(t *testing.T, _ ...string) (string, string) {
+	t.Helper()
+
+	t.Errorf("unexpected call to gh")
+
+	return "", ""
+}
+
+func expectCallToGh(t *testing.T, _ ...string) (string, string) {
+	t.Helper()
+
+	return "https://github.com/octocat/hello-world", ""
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -147,6 +147,7 @@ func writeTempConfigFile(t *testing.T, content string) string {
 	return f.Name()
 }
 
+// expectNoCallToGh fails the test if it is called
 func expectNoCallToGh(t *testing.T, _ ...string) (string, string) {
 	t.Helper()
 
@@ -155,6 +156,7 @@ func expectNoCallToGh(t *testing.T, _ ...string) (string, string) {
 	return "", ""
 }
 
+// expectCallToGh acts as a successful call to gh.Exec
 func expectCallToGh(t *testing.T, _ ...string) (string, string) {
 	t.Helper()
 

--- a/main_test.go
+++ b/main_test.go
@@ -308,6 +308,7 @@ func Test_run(t *testing.T) {
 	type args struct {
 		args   []string
 		config string
+		ghExec func(t *testing.T, args ...string) (string, string)
 	}
 	tests := []struct {
 		name string
@@ -318,6 +319,7 @@ func Test_run(t *testing.T) {
 			name: "repository must be provided as the first argument",
 			args: args{
 				args:   []string{},
+				ghExec: expectNoCallToGh,
 				config: "",
 			},
 			exit: 1,
@@ -326,6 +328,7 @@ func Test_run(t *testing.T) {
 			name: "repository must be prefixed with owner",
 			args: args{
 				args:   []string{"hello-world"},
+				ghExec: expectNoCallToGh,
 				config: "",
 			},
 			exit: 1,
@@ -334,6 +337,7 @@ func Test_run(t *testing.T) {
 			name: "repository should not be a url",
 			args: args{
 				args:   []string{"https://github.com/octocat/hello-world"},
+				ghExec: expectNoCallToGh,
 				config: "",
 			},
 			exit: 1,
@@ -342,6 +346,7 @@ func Test_run(t *testing.T) {
 			name: "target is not required",
 			args: args{
 				args:   []string{"octocat/hello-world", "abc"},
+				ghExec: expectCallToGh,
 				config: "",
 			},
 			exit: 1,
@@ -350,6 +355,7 @@ func Test_run(t *testing.T) {
 			name: "target does not have to be a number",
 			args: args{
 				args:   []string{"octocat/hello-world"},
+				ghExec: expectCallToGh,
 				config: "",
 			},
 			exit: 1,
@@ -358,6 +364,7 @@ func Test_run(t *testing.T) {
 			name: "config does not exist",
 			args: args{
 				args:   []string{"octocat/hello-world", "123"},
+				ghExec: expectNoCallToGh,
 				config: "",
 			},
 			exit: 1,
@@ -366,6 +373,7 @@ func Test_run(t *testing.T) {
 			name: "invalid config",
 			args: args{
 				args:   []string{"octocat/hello-world", "123"},
+				ghExec: expectNoCallToGh,
 				config: "!!!",
 			},
 			exit: 1,
@@ -373,7 +381,8 @@ func Test_run(t *testing.T) {
 		{
 			name: "repository does not exist in config",
 			args: args{
-				args: []string{"octocat/hello-world", "123"},
+				args:   []string{"octocat/hello-world", "123"},
+				ghExec: expectNoCallToGh,
 				config: `
 					repositories:
 						octocat/hello-sunshine:
@@ -387,7 +396,8 @@ func Test_run(t *testing.T) {
 		{
 			name: "group does not exist in config",
 			args: args{
-				args: []string{"--from", "does-not-exist", "octocat/hello-world", "123"},
+				args:   []string{"--from", "does-not-exist", "octocat/hello-world", "123"},
+				ghExec: expectNoCallToGh,
 				config: `
 					repositories:
 						octocat/hello-world:
@@ -401,7 +411,8 @@ func Test_run(t *testing.T) {
 		{
 			name: "fulsome case",
 			args: args{
-				args: []string{"octocat/hello-world", "123"},
+				args:   []string{"octocat/hello-world", "123"},
+				ghExec: expectCallToGh,
 				config: `
 					repositories:
 						octocat/hello-world:
@@ -418,7 +429,8 @@ func Test_run(t *testing.T) {
 		{
 			name: "dry run",
 			args: args{
-				args: []string{"--dry-run", "octocat/hello-world", "123"},
+				args:   []string{"--dry-run", "octocat/hello-world", "123"},
+				ghExec: expectNoCallToGh,
 				config: `
 					repositories:
 						octocat/hello-world:
@@ -435,7 +447,8 @@ func Test_run(t *testing.T) {
 		{
 			name: "explicit group",
 			args: args{
-				args: []string{"--from", "infra", "octocat/hello-world", "123"},
+				args:   []string{"--from", "infra", "octocat/hello-world", "123"},
+				ghExec: expectCallToGh,
 				config: `
 					repositories:
 						octocat/hello-world:
@@ -451,6 +464,31 @@ func Test_run(t *testing.T) {
 				`,
 			},
 			exit: 0,
+		},
+		{
+			name: "when ghExec fails",
+			args: args{
+				args: []string{"octocat/hello-world"},
+				ghExec: func(t *testing.T, args ...string) (string, string) {
+					t.Helper()
+
+					return "", "no pull requests found for branch \"update-readme\""
+				},
+				config: `
+					repositories:
+						octocat/hello-world:
+							default:
+								- octocat
+							infra:
+								- octodog
+								- octopus
+						octocat/hello-sunshine:
+							default:
+								- octodog
+								- octopus
+				`,
+			},
+			exit: 1,
 		},
 	}
 	for _, tt := range tests {
@@ -469,7 +507,7 @@ func Test_run(t *testing.T) {
 			got := run(a, stdout, stderr, func(args ...string) (stdout, stderr string) {
 				t.Helper()
 
-				return "https://github.com/octocat/hello-world", ""
+				return tt.args.ghExec(t, args...)
 			})
 
 			if got != tt.exit {
@@ -491,9 +529,7 @@ func Test_run_WithNoHomeVar(t *testing.T) {
 	run([]string{}, &bytes.Buffer{}, &bytes.Buffer{}, func(args ...string) (stdout, stderr string) {
 		t.Helper()
 
-		t.Fatalf("unexpected call to gh")
-
-		return "", ""
+		return expectNoCallToGh(t, args...)
 	})
 
 	t.Errorf("function did not panic when home directory could not be found")

--- a/main_test.go
+++ b/main_test.go
@@ -504,8 +504,14 @@ func Test_run(t *testing.T) {
 			a := []string{"--config-dir", configDir}
 			a = append(a, tt.args.args...)
 
+			var ghExecArgs []string
+			ghExecCalled := false
+
 			got := run(a, stdout, stderr, func(args ...string) (stdout, stderr string) {
 				t.Helper()
+
+				ghExecArgs = args
+				ghExecCalled = true
 
 				return tt.args.ghExec(t, args...)
 			})
@@ -516,6 +522,10 @@ func Test_run(t *testing.T) {
 
 			snaps.MatchSnapshot(t, normalizeStdStream(t, stdout))
 			snaps.MatchSnapshot(t, normalizeStdStream(t, stderr))
+
+			if ghExecCalled {
+				snaps.MatchJSON(t, ghExecArgs)
+			}
 		})
 	}
 }


### PR DESCRIPTION
By passing in `gh.Exec` as an argument to `run` it lets us get a bit more test coverage since we can pass in our own stub function that asserts if it was called or not and also records the arguments.

This is a little iffy because (in addition to just the fact that we're passing a function) the naming is generic but all our implementations assume we're calling `gh pr edit` once, but I don't think it's worth the extra code faff to clean that up right now since we can manually verify that is the only way it's being invoked