### PR TITLE
test: improve how `gh.Exec` stubbing is handled

### DIFF
--- a/__snapshots__/main_test.snap
+++ b/__snapshots__/main_test.snap
@@ -8,6 +8,10 @@ please create <tempdir>/gh-rr.yml to configure your repositories
 
 ---
 
+[Test_run/config_does_not_exist - 3]
+null
+---
+
 [Test_run/dry_run - 1]
 would have used `gh pr edit` to request reviews from:
   - octocat
@@ -16,6 +20,10 @@ would have used `gh pr edit` to request reviews from:
 
 [Test_run/dry_run - 2]
 
+---
+
+[Test_run/dry_run - 3]
+null
 ---
 
 [Test_run/explicit_group - 1]
@@ -77,6 +85,10 @@ octocat/hello-world does not have a group named does-not-exist
 
 ---
 
+[Test_run/group_does_not_exist_in_config - 3]
+null
+---
+
 [Test_run/invalid_config - 1]
 
 ---
@@ -85,6 +97,10 @@ octocat/hello-world does not have a group named does-not-exist
 yaml: unmarshal errors:
   line 1: cannot unmarshal !!! `` into main.Config
 
+---
+
+[Test_run/invalid_config - 3]
+null
 ---
 
 [Test_run/repository_does_not_exist_in_config - 1]
@@ -96,6 +112,10 @@ no reviewers are configured for octocat/hello-world
 
 ---
 
+[Test_run/repository_does_not_exist_in_config - 3]
+null
+---
+
 [Test_run/repository_must_be_prefixed_with_owner - 1]
 
 ---
@@ -103,6 +123,10 @@ no reviewers are configured for octocat/hello-world
 [Test_run/repository_must_be_prefixed_with_owner - 2]
 repository should be in the format of <owner>/<repository>
 
+---
+
+[Test_run/repository_must_be_prefixed_with_owner - 3]
+null
 ---
 
 [Test_run/repository_must_be_provided_as_the_first_argument - 1]
@@ -114,6 +138,10 @@ first argument must be repository in <owner>/<repository> format
 
 ---
 
+[Test_run/repository_must_be_provided_as_the_first_argument - 3]
+null
+---
+
 [Test_run/repository_should_not_be_a_url - 1]
 
 ---
@@ -121,6 +149,10 @@ first argument must be repository in <owner>/<repository> format
 [Test_run/repository_should_not_be_a_url - 2]
 repository should be in the format of <owner>/<repository>
 
+---
+
+[Test_run/repository_should_not_be_a_url - 3]
+null
 ---
 
 [Test_run/target_does_not_have_to_be_a_number - 1]
@@ -132,6 +164,10 @@ please create <tempdir>/gh-rr.yml to configure your repositories
 
 ---
 
+[Test_run/target_does_not_have_to_be_a_number - 3]
+null
+---
+
 [Test_run/target_is_not_required - 1]
 
 ---
@@ -139,6 +175,10 @@ please create <tempdir>/gh-rr.yml to configure your repositories
 [Test_run/target_is_not_required - 2]
 please create <tempdir>/gh-rr.yml to configure your repositories
 
+---
+
+[Test_run/target_is_not_required - 3]
+null
 ---
 
 [Test_run/when_ghExec_fails - 1]

--- a/__snapshots__/main_test.snap
+++ b/__snapshots__/main_test.snap
@@ -19,7 +19,7 @@ would have used `gh pr edit` to request reviews from:
 ---
 
 [Test_run/explicit_group - 1]
-requested reviews on https://github.com/octocat/hello-world from:
+requested reviews on https://github.com/octocat/hello-world/pull/123 from:
   - octodog
   - octopus
 
@@ -44,8 +44,9 @@ requested reviews on https://github.com/octocat/hello-world from:
 ---
 
 [Test_run/fulsome_case - 1]
-requested reviews on https://github.com/octocat/hello-world from:
-  - octocat
+requested reviews on https://github.com/octocat/hello-sunshine/pull/123 from:
+  - octodog
+  - octopus
 
 ---
 
@@ -59,9 +60,11 @@ requested reviews on https://github.com/octocat/hello-world from:
  "edit",
  "123",
  "--repo",
- "octocat/hello-world",
+ "octocat/hello-sunshine",
  "--add-reviewer",
- "octocat"
+ "octodog",
+ "--add-reviewer",
+ "octopus"
 ]
 ---
 

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -147,18 +148,26 @@ func writeTempConfigFile(t *testing.T, content string) string {
 	return f.Name()
 }
 
-// expectNoCallToGh fails the test if it is called
-func expectNoCallToGh(t *testing.T, _ ...string) (string, string) {
+// expectNoCallToGh builds a function that fails the test if it is called
+func expectNoCallToGh(t *testing.T) ghExecutor {
 	t.Helper()
 
-	t.Errorf("unexpected call to gh")
+	return func(_ ...string) (string, string) {
+		t.Helper()
 
-	return "", ""
+		t.Errorf("unexpected call to gh")
+
+		return "", ""
+	}
 }
 
-// expectCallToGh acts as a successful call to gh.Exec
-func expectCallToGh(t *testing.T, _ ...string) (string, string) {
+// expectCallToGh builds a function that acts as a successful call to gh.Exec
+func expectCallToGh(t *testing.T, repo, target string) ghExecutor {
 	t.Helper()
 
-	return "https://github.com/octocat/hello-world", ""
+	return func(_ ...string) (string, string) {
+		t.Helper()
+
+		return fmt.Sprintf("https://github.com/%s/pull/%s", repo, target), ""
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -505,13 +505,11 @@ func Test_run(t *testing.T) {
 			a = append(a, tt.args.args...)
 
 			var ghExecArgs []string
-			ghExecCalled := false
 
 			got := run(a, stdout, stderr, func(args ...string) (stdout, stderr string) {
 				t.Helper()
 
 				ghExecArgs = args
-				ghExecCalled = true
 
 				return tt.args.ghExec(args...)
 			})
@@ -522,10 +520,7 @@ func Test_run(t *testing.T) {
 
 			snaps.MatchSnapshot(t, normalizeStdStream(t, stdout))
 			snaps.MatchSnapshot(t, normalizeStdStream(t, stderr))
-
-			if ghExecCalled {
-				snaps.MatchJSON(t, ghExecArgs)
-			}
+			snaps.MatchJSON(t, ghExecArgs)
 		})
 	}
 }


### PR DESCRIPTION
While working on other stuff I realised that it's confusing to always return a hardcoded value for the PR url since it sometimes doesn't align with the tests, and it's better to always create a snapshot of the `gh.Exec` args even when we don't expect it to be called as it makes for a better diff if things change