### PR TITLE
feat: switch to using `--repo` for providing the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,21 +32,27 @@ Then start requesting reviewers on your pull requests:
 
 ```shell
 # will infer the pull request to target based on the current branch
-gh rr g-rath/my-awesome-app
+gh rr --repo g-rath/my-awesome-app
 
 # will infer the pull request based on the named branch
-gh rr g-rath/my-awesome-app my-feature
+gh rr --repo g-rath/my-awesome-app my-feature
 
 # will target the specific pull request
-gh rr g-rath/my-awesome-app 123
+gh rr --repo g-rath/my-awesome-app 123
 ```
 
-Under the hood this extension uses
-[`gh pr edit`](https://cli.github.com/manual/gh_pr_edit) to add reviewers, with
-the second argument being provided as that commands first argument.
+As a thin wrapper around
+[`gh pr edit`](https://cli.github.com/manual/gh_pr_edit), the first argument is
+passed directly through to the cli, so you can provide a pull request number,
+url, branch, or nothing at all!
+
+> [!NOTE]
+>
+> Currently unlike the `gh` cli, the `--repo` flag is required and the `-R`
+> short-flag is not supported
 
 You can specify specific groups using `--from`:
 
 ```shell
-gh rr --from infra g-rath/my-awesome-app 123
+gh rr --from infra --repo g-rath/my-awesome-app 123
 ```

--- a/__snapshots__/main_test.snap
+++ b/__snapshots__/main_test.snap
@@ -116,68 +116,29 @@ no reviewers are configured for octocat/hello-world
 null
 ---
 
-[Test_run/repository_must_be_prefixed_with_owner - 1]
+[Test_run/when_--repo_is_a_url - 1]
 
 ---
 
-[Test_run/repository_must_be_prefixed_with_owner - 2]
+[Test_run/when_--repo_is_a_url - 2]
 repository should be in the format of <owner>/<repository>
 
 ---
 
-[Test_run/repository_must_be_prefixed_with_owner - 3]
+[Test_run/when_--repo_is_a_url - 3]
 null
 ---
 
-[Test_run/repository_must_be_provided_as_the_first_argument - 1]
+[Test_run/when_--repo_is_not_prefixed_with_the_owner - 1]
 
 ---
 
-[Test_run/repository_must_be_provided_as_the_first_argument - 2]
-first argument must be repository in <owner>/<repository> format
-
----
-
-[Test_run/repository_must_be_provided_as_the_first_argument - 3]
-null
----
-
-[Test_run/repository_should_not_be_a_url - 1]
-
----
-
-[Test_run/repository_should_not_be_a_url - 2]
+[Test_run/when_--repo_is_not_prefixed_with_the_owner - 2]
 repository should be in the format of <owner>/<repository>
 
 ---
 
-[Test_run/repository_should_not_be_a_url - 3]
-null
----
-
-[Test_run/target_does_not_have_to_be_a_number - 1]
-
----
-
-[Test_run/target_does_not_have_to_be_a_number - 2]
-please create <tempdir>/gh-rr.yml to configure your repositories
-
----
-
-[Test_run/target_does_not_have_to_be_a_number - 3]
-null
----
-
-[Test_run/target_is_not_required - 1]
-
----
-
-[Test_run/target_is_not_required - 2]
-please create <tempdir>/gh-rr.yml to configure your repositories
-
----
-
-[Test_run/target_is_not_required - 3]
+[Test_run/when_--repo_is_not_prefixed_with_the_owner - 3]
 null
 ---
 
@@ -200,5 +161,68 @@ could not add reviewers: no pull requests found for branch "update-readme"
  "octocat/hello-world",
  "--add-reviewer",
  "octocat"
+]
+---
+
+[Test_run/when_no_arguments_are_provided - 1]
+requested reviews on https://github.com/octocat/hello-world/pull/ from:
+  - octodog
+  - octopus
+
+---
+
+[Test_run/when_no_arguments_are_provided - 2]
+
+---
+
+[Test_run/when_no_arguments_are_provided - 3]
+[
+ "pr",
+ "edit",
+ "",
+ "--repo",
+ "octocat/hello-world",
+ "--add-reviewer",
+ "octodog",
+ "--add-reviewer",
+ "octopus"
+]
+---
+
+[Test_run/when_the_--repo_flag_is_not_provided - 1]
+
+---
+
+[Test_run/when_the_--repo_flag_is_not_provided - 2]
+--repo flag is required and must be in <owner>/<repository> format
+
+---
+
+[Test_run/when_the_--repo_flag_is_not_provided - 3]
+null
+---
+
+[Test_run/when_the_target_is_not_a_number - 1]
+requested reviews on https://github.com/octodog/hello-cat/pull/abc from:
+  - octodog
+  - octopus
+
+---
+
+[Test_run/when_the_target_is_not_a_number - 2]
+
+---
+
+[Test_run/when_the_target_is_not_a_number - 3]
+[
+ "pr",
+ "edit",
+ "abc",
+ "--repo",
+ "octodog/hello-cat",
+ "--add-reviewer",
+ "octodog",
+ "--add-reviewer",
+ "octopus"
 ]
 ---

--- a/main_test.go
+++ b/main_test.go
@@ -316,7 +316,7 @@ func Test_run(t *testing.T) {
 		exit int
 	}{
 		{
-			name: "repository must be provided as the first argument",
+			name: "when the --repo flag is not provided",
 			args: args{
 				args:   []string{},
 				ghExec: expectNoCallToGh(t),
@@ -325,45 +325,57 @@ func Test_run(t *testing.T) {
 			exit: 1,
 		},
 		{
-			name: "repository must be prefixed with owner",
+			name: "when --repo is not prefixed with the owner",
 			args: args{
-				args:   []string{"hello-world"},
+				args:   []string{"--repo", "hello-world"},
 				ghExec: expectNoCallToGh(t),
 				config: "",
 			},
 			exit: 1,
 		},
 		{
-			name: "repository should not be a url",
+			name: "when --repo is a url",
 			args: args{
-				args:   []string{"https://github.com/octocat/hello-world"},
+				args:   []string{"--repo", "https://github.com/octocat/hello-world"},
 				ghExec: expectNoCallToGh(t),
 				config: "",
 			},
 			exit: 1,
 		},
 		{
-			name: "target is not required",
+			name: "when no arguments are provided",
 			args: args{
-				args:   []string{"octocat/hello-world", "abc"},
-				ghExec: expectCallToGh(t, "octocat/hello-world", "abc"),
-				config: "",
-			},
-			exit: 1,
-		},
-		{
-			name: "target does not have to be a number",
-			args: args{
-				args:   []string{"octocat/hello-world"},
+				args:   []string{"--repo", "octocat/hello-world"},
 				ghExec: expectCallToGh(t, "octocat/hello-world", ""),
-				config: "",
+				config: `
+					repositories:
+						octocat/hello-world:
+							default:
+								- octodog
+								- octopus
+				`,
 			},
-			exit: 1,
+			exit: 0,
+		},
+		{
+			name: "when the target is not a number",
+			args: args{
+				args:   []string{"--repo", "octodog/hello-cat", "abc"},
+				ghExec: expectCallToGh(t, "octodog/hello-cat", "abc"),
+				config: `
+					repositories:
+						octodog/hello-cat:
+							default:
+								- octodog
+								- octopus
+				`,
+			},
+			exit: 0,
 		},
 		{
 			name: "config does not exist",
 			args: args{
-				args:   []string{"octocat/hello-world", "123"},
+				args:   []string{"--repo", "octocat/hello-world", "123"},
 				ghExec: expectNoCallToGh(t),
 				config: "",
 			},
@@ -372,7 +384,7 @@ func Test_run(t *testing.T) {
 		{
 			name: "invalid config",
 			args: args{
-				args:   []string{"octocat/hello-world", "123"},
+				args:   []string{"--repo", "octocat/hello-world", "123"},
 				ghExec: expectNoCallToGh(t),
 				config: "!!!",
 			},
@@ -381,7 +393,7 @@ func Test_run(t *testing.T) {
 		{
 			name: "repository does not exist in config",
 			args: args{
-				args:   []string{"octocat/hello-world", "123"},
+				args:   []string{"--repo", "octocat/hello-world", "123"},
 				ghExec: expectNoCallToGh(t),
 				config: `
 					repositories:
@@ -396,7 +408,7 @@ func Test_run(t *testing.T) {
 		{
 			name: "group does not exist in config",
 			args: args{
-				args:   []string{"--from", "does-not-exist", "octocat/hello-world", "123"},
+				args:   []string{"--from", "does-not-exist", "--repo", "octocat/hello-world", "123"},
 				ghExec: expectNoCallToGh(t),
 				config: `
 					repositories:
@@ -411,7 +423,7 @@ func Test_run(t *testing.T) {
 		{
 			name: "fulsome case",
 			args: args{
-				args:   []string{"octocat/hello-sunshine", "123"},
+				args:   []string{"--repo", "octocat/hello-sunshine", "123"},
 				ghExec: expectCallToGh(t, "octocat/hello-sunshine", "123"),
 				config: `
 					repositories:
@@ -429,7 +441,7 @@ func Test_run(t *testing.T) {
 		{
 			name: "dry run",
 			args: args{
-				args:   []string{"--dry-run", "octocat/hello-world", "123"},
+				args:   []string{"--dry-run", "--repo", "octocat/hello-world", "123"},
 				ghExec: expectNoCallToGh(t),
 				config: `
 					repositories:
@@ -447,7 +459,7 @@ func Test_run(t *testing.T) {
 		{
 			name: "explicit group",
 			args: args{
-				args:   []string{"--from", "infra", "octocat/hello-world", "123"},
+				args:   []string{"--from", "infra", "--repo", "octocat/hello-world", "123"},
 				ghExec: expectCallToGh(t, "octocat/hello-world", "123"),
 				config: `
 					repositories:
@@ -468,7 +480,7 @@ func Test_run(t *testing.T) {
 		{
 			name: "when ghExec fails",
 			args: args{
-				args: []string{"octocat/hello-world"},
+				args: []string{"--repo", "octocat/hello-world"},
 				ghExec: func(_ ...string) (string, string) {
 					t.Helper()
 


### PR DESCRIPTION
This switches us from taking the repository as the first argument to taking it via the `--repo` flag, meaning we more closely match `gh pr edit` (since our first argument matches their first argument) and paving the way for inferring the repository based on the current directory by default (#2).

Resolves #6