### PR TITLE
feat: infer repository based on the current directory

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,9 +22,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    env:
+      # used by `repository.Current` as an override
+      GH_REPO: 'G-Rath/gh-rr'
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-        with:
-          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@v5
         with:

--- a/README.md
+++ b/README.md
@@ -31,28 +31,32 @@ repositories:
 Then start requesting reviewers on your pull requests:
 
 ```shell
-# will infer the pull request to target based on the current branch
-gh rr --repo g-rath/my-awesome-app
-
-# will infer the pull request based on the named branch
-gh rr --repo g-rath/my-awesome-app my-feature
-
-# will target the specific pull request
-gh rr --repo g-rath/my-awesome-app 123
+gh rr
 ```
 
 As a thin wrapper around
-[`gh pr edit`](https://cli.github.com/manual/gh_pr_edit), the first argument is
-passed directly through to the cli, so you can provide a pull request number,
-url, branch, or nothing at all!
+[`gh pr edit`](https://cli.github.com/manual/gh_pr_edit), the repository and
+pull request are inferred automatically based on the current directory and
+checked out branch when called without any flags or arguments.
+
+Like with `gh pr edit`, you can pass either a pull request number, url, or
+branch as the first argument, and can use the `--repo` flag to specify the
+repository the pull request you're targeting belongs to:
+
+```shell
+# targeting a specific pull request in the current repository
+gh rr 123
+
+# targeting the pull request associated with a specific branch in another repository
+gh --repo octocat/hello-world my-feature
+```
 
 > [!NOTE]
 >
-> Currently unlike the `gh` cli, the `--repo` flag is required and the `-R`
-> short-flag is not supported
+> Currently, unlike the `gh` cli, the `-R` short-flag is not supported
 
-You can specify specific groups using `--from`:
+You can also use the `--from` flag to target alternative reviewer groups:
 
 ```shell
-gh rr --from infra --repo g-rath/my-awesome-app 123
+gh rr --from infra
 ```

--- a/__snapshots__/main_test.snap
+++ b/__snapshots__/main_test.snap
@@ -13,7 +13,7 @@ null
 ---
 
 [Test_run/dry_run - 1]
-would have used `gh pr edit` to request reviews from:
+would have used `gh pr edit --repo octocat/hello-world` to request reviews from:
   - octocat
 
 ---

--- a/__snapshots__/main_test.snap
+++ b/__snapshots__/main_test.snap
@@ -51,31 +51,6 @@ requested reviews on https://github.com/octocat/hello-world/pull/123 from:
 ]
 ---
 
-[Test_run/fulsome_case - 1]
-requested reviews on https://github.com/octocat/hello-sunshine/pull/123 from:
-  - octodog
-  - octopus
-
----
-
-[Test_run/fulsome_case - 2]
-
----
-
-[Test_run/fulsome_case - 3]
-[
- "pr",
- "edit",
- "123",
- "--repo",
- "octocat/hello-sunshine",
- "--add-reviewer",
- "octodog",
- "--add-reviewer",
- "octopus"
-]
----
-
 [Test_run/group_does_not_exist_in_config - 1]
 
 ---
@@ -142,6 +117,44 @@ repository should be in the format of <owner>/<repository>
 null
 ---
 
+[Test_run/when_--repo_is_not_prefixed_with_the_owner#01 - 1]
+
+---
+
+[Test_run/when_--repo_is_not_prefixed_with_the_owner#01 - 2]
+repository should be in the format of <owner>/<repository>
+
+---
+
+[Test_run/when_--repo_is_not_prefixed_with_the_owner#01 - 3]
+null
+---
+
+[Test_run/when_--repo_is_provided - 1]
+requested reviews on https://github.com/octocat/hello-sunshine/pull/123 from:
+  - octodog
+  - octopus
+
+---
+
+[Test_run/when_--repo_is_provided - 2]
+
+---
+
+[Test_run/when_--repo_is_provided - 3]
+[
+ "pr",
+ "edit",
+ "123",
+ "--repo",
+ "octocat/hello-sunshine",
+ "--add-reviewer",
+ "octodog",
+ "--add-reviewer",
+ "octopus"
+]
+---
+
 [Test_run/when_ghExec_fails - 1]
 
 could not add reviewers: no pull requests found for branch "update-readme"
@@ -189,21 +202,8 @@ requested reviews on https://github.com/octocat/hello-world/pull/ from:
 ]
 ---
 
-[Test_run/when_the_--repo_flag_is_not_provided - 1]
-
----
-
-[Test_run/when_the_--repo_flag_is_not_provided - 2]
---repo flag is required and must be in <owner>/<repository> format
-
----
-
-[Test_run/when_the_--repo_flag_is_not_provided - 3]
-null
----
-
 [Test_run/when_the_target_is_not_a_number - 1]
-requested reviews on https://github.com/octodog/hello-cat/pull/abc from:
+requested reviews on https://github.com/octocat/hello=world/pull/abc from:
   - octodog
   - octopus
 
@@ -219,10 +219,32 @@ requested reviews on https://github.com/octodog/hello-cat/pull/abc from:
  "edit",
  "abc",
  "--repo",
- "octodog/hello-cat",
+ "octocat/hello-world",
  "--add-reviewer",
  "octodog",
  "--add-reviewer",
  "octopus"
+]
+---
+
+[Test_run_WithoutRepoFlag - 1]
+requested reviews on https://github.com/G-Rath/gh-rr from:
+  - octocat
+
+---
+
+[Test_run_WithoutRepoFlag - 2]
+
+---
+
+[Test_run_WithoutRepoFlag - 3]
+[
+ "pr",
+ "edit",
+ "",
+ "--repo",
+ "G-Rath/gh-rr",
+ "--add-reviewer",
+ "octocat"
 ]
 ---

--- a/main.go
+++ b/main.go
@@ -160,7 +160,7 @@ func run(args []string, stdout, stderr io.Writer, ghExec ghExecutor) int {
 	}
 
 	if *isDryRun {
-		fmt.Fprintf(stdout, "would have used `gh pr edit` to request reviews from:\n")
+		fmt.Fprintf(stdout, "would have used `gh pr edit --repo %s` to request reviews from:\n", repo)
 	} else {
 		url, errMsg := ghExec(buildAddReviewersArgs(repo, target, reviewers)...)
 

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/cli/go-gh/v2"
+	"github.com/cli/go-gh/v2/pkg/repository"
 	"gopkg.in/yaml.v3"
 )
 
@@ -86,20 +87,14 @@ func mustGetUserHomeDir() string {
 	return dir
 }
 
-func validateRepositoryFlag(stderr io.Writer, repo string) bool {
-	if repo == "" {
-		fmt.Fprintln(stderr, "--repo flag is required and must be in <owner>/<repository> format")
+func inferCurrentRepository() (string, error) {
+	repo, err := repository.Current()
 
-		return false
+	if err != nil {
+		return "", err
 	}
 
-	if _, _, found := strings.Cut(repo, "/"); !found || strings.HasPrefix(repo, "http") {
-		fmt.Fprintln(stderr, "repository should be in the format of <owner>/<repository>")
-
-		return false
-	}
-
-	return true
+	return fmt.Sprintf("%s/%s", repo.Owner, repo.Name), nil
 }
 
 // ghExecutor invokes a gh command in a subprocess and captures the output and error streams
@@ -108,7 +103,7 @@ type ghExecutor = func(args ...string) (stdout, stderr string)
 func run(args []string, stdout, stderr io.Writer, ghExec ghExecutor) int {
 	cli := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
-	repo := cli.String("repo", "", "select another repository using the [HOST/]OWNER/REPO format")
+	repoF := cli.String("repo", "", "select another repository using the [HOST/]OWNER/REPO format")
 	group := cli.String("from", "default", "group of users to request review from")
 	configDir := cli.String("config-dir", mustGetUserHomeDir(), "directory to search for the configuration file")
 	isDryRun := cli.Bool("dry-run", false, "")
@@ -118,7 +113,22 @@ func run(args []string, stdout, stderr io.Writer, ghExec ghExecutor) int {
 
 	target := cli.Arg(0)
 
-	if !validateRepositoryFlag(stderr, *repo) {
+	repo := *repoF
+
+	var err error
+	if repo == "" {
+		repo, err = inferCurrentRepository()
+
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "could not determine repository: %v\n", err)
+
+			return 1
+		}
+	}
+
+	if _, _, found := strings.Cut(repo, "/"); !found || strings.HasPrefix(repo, "http") {
+		fmt.Fprintln(stderr, "repository should be in the format of <owner>/<repository>")
+
 		return 1
 	}
 
@@ -135,13 +145,13 @@ func run(args []string, stdout, stderr io.Writer, ghExec ghExecutor) int {
 		return 1
 	}
 
-	reviewers, err := determineReviewers(config, *repo, *group)
+	reviewers, err := determineReviewers(config, repo, *group)
 
 	if err != nil {
 		if errors.Is(err, ErrRepositoryNotConfigured) {
-			fmt.Fprintf(stderr, "no reviewers are configured for %s\n", *repo)
+			fmt.Fprintf(stderr, "no reviewers are configured for %s\n", repo)
 		} else if errors.Is(err, ErrGroupNotConfigured) {
-			fmt.Fprintf(stderr, "%s does not have a group named %s\n", *repo, *group)
+			fmt.Fprintf(stderr, "%s does not have a group named %s\n", repo, *group)
 		} else {
 			fmt.Fprintf(stderr, "%v\n", err)
 		}
@@ -152,7 +162,7 @@ func run(args []string, stdout, stderr io.Writer, ghExec ghExecutor) int {
 	if *isDryRun {
 		fmt.Fprintf(stdout, "would have used `gh pr edit` to request reviews from:\n")
 	} else {
-		url, errMsg := ghExec(buildAddReviewersArgs(*repo, target, reviewers)...)
+		url, errMsg := ghExec(buildAddReviewersArgs(repo, target, reviewers)...)
 
 		if errMsg != "" {
 			fmt.Fprintf(stdout, "\ncould not add reviewers: %s\n", strings.TrimSpace(errMsg))


### PR DESCRIPTION
This makes the `--repo` flag optional as we now infer the repository based on the current directory, just like how the `gh` cli does it.

Resolves #2