### PR TITLE
feat: support short-flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ pull request are inferred automatically based on the current directory and
 checked out branch when called without any flags or arguments.
 
 Like with `gh pr edit`, you can pass either a pull request number, url, or
-branch as the first argument, and can use the `--repo` flag to specify the
+branch as the first argument, and can use the `-R|--repo` flag to specify the
 repository the pull request you're targeting belongs to:
 
 ```shell
@@ -51,11 +51,7 @@ gh rr 123
 gh --repo octocat/hello-world my-feature
 ```
 
-> [!NOTE]
->
-> Currently, unlike the `gh` cli, the `-R` short-flag is not supported
-
-You can also use the `--from` flag to target alternative reviewer groups:
+You can also use the `-f|--from` flag to target alternative reviewer groups:
 
 ```shell
 gh rr --from infra

--- a/__snapshots__/main_test.snap
+++ b/__snapshots__/main_test.snap
@@ -155,6 +155,56 @@ requested reviews on https://github.com/octocat/hello-sunshine/pull/123 from:
 ]
 ---
 
+[Test_run/when_-R_is_provided - 1]
+requested reviews on https://github.com/octocat/hello-sunshine/pull/123 from:
+  - octodog
+  - octopus
+
+---
+
+[Test_run/when_-R_is_provided - 2]
+
+---
+
+[Test_run/when_-R_is_provided - 3]
+[
+ "pr",
+ "edit",
+ "123",
+ "--repo",
+ "octocat/hello-sunshine",
+ "--add-reviewer",
+ "octodog",
+ "--add-reviewer",
+ "octopus"
+]
+---
+
+[Test_run/when_a_group_is_provided_(shorthand) - 1]
+requested reviews on https://github.com/octocat/hello-world/pull/123 from:
+  - octodog
+  - octopus
+
+---
+
+[Test_run/when_a_group_is_provided_(shorthand) - 2]
+
+---
+
+[Test_run/when_a_group_is_provided_(shorthand) - 3]
+[
+ "pr",
+ "edit",
+ "123",
+ "--repo",
+ "octocat/hello-world",
+ "--add-reviewer",
+ "octodog",
+ "--add-reviewer",
+ "octopus"
+]
+---
+
 [Test_run/when_an_unknown_flag_is_requested - 1]
 
 ---
@@ -198,8 +248,8 @@ could not add reviewers: no pull requests found for branch "update-readme"
 Usage of gh rr:
       --config-dir string   directory to search for the configuration file (default "<homedir>")
       --dry-run             outputs instead of executing gh
-      --from string         group of users to request review from (default "default")
-      --repo string         select another repository using the [HOST/]OWNER/REPO format
+  -f, --from string         group of users to request review from (default "default")
+  -R, --repo string         select another repository using the [HOST/]OWNER/REPO format
 
 ---
 

--- a/__snapshots__/main_test.snap
+++ b/__snapshots__/main_test.snap
@@ -155,6 +155,19 @@ requested reviews on https://github.com/octocat/hello-sunshine/pull/123 from:
 ]
 ---
 
+[Test_run/when_an_unknown_flag_is_requested - 1]
+
+---
+
+[Test_run/when_an_unknown_flag_is_requested - 2]
+unknown flag: --blah
+
+---
+
+[Test_run/when_an_unknown_flag_is_requested - 3]
+null
+---
+
 [Test_run/when_ghExec_fails - 1]
 
 could not add reviewers: no pull requests found for branch "update-readme"
@@ -175,6 +188,23 @@ could not add reviewers: no pull requests found for branch "update-readme"
  "--add-reviewer",
  "octocat"
 ]
+---
+
+[Test_run/when_help_is_requested - 1]
+
+---
+
+[Test_run/when_help_is_requested - 2]
+Usage of gh rr:
+      --config-dir string   directory to search for the configuration file (default "<homedir>")
+      --dry-run             outputs instead of executing gh
+      --from string         group of users to request review from (default "default")
+      --repo string         select another repository using the [HOST/]OWNER/REPO format
+
+---
+
+[Test_run/when_help_is_requested - 3]
+null
 ---
 
 [Test_run/when_no_arguments_are_provided - 1]

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21.5
 require (
 	github.com/cli/go-gh/v2 v2.8.0
 	github.com/gkampitakis/go-snaps v0.5.3
+	github.com/spf13/pflag v1.0.5
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/cli/go-gh/v2 v2.8.0 h1:xFDgnhRiVMFanqACszdyRduUaFkoMOiasOrox0sKpKo=
@@ -41,6 +43,8 @@ github.com/rivo/uniseg v0.4.7/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUc
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/thlib/go-timezone-local v0.0.0-20210907160436-ef149e42d28e h1:BuzhfgfWQbX0dWzYzT1zsORLnHRv3bcRcsaUk0VmXA8=

--- a/main.go
+++ b/main.go
@@ -103,8 +103,8 @@ type ghExecutor = func(args ...string) (stdout, stderr string)
 func run(args []string, stdout, stderr io.Writer, ghExec ghExecutor) int {
 	cli := flag.NewFlagSet("gh rr", flag.ContinueOnError)
 
-	repoF := cli.String("repo", "", "select another repository using the [HOST/]OWNER/REPO format")
-	group := cli.String("from", "default", "group of users to request review from")
+	repoF := cli.StringP("repo", "R", "", "select another repository using the [HOST/]OWNER/REPO format")
+	group := cli.StringP("from", "f", "default", "group of users to request review from")
 	configDir := cli.String("config-dir", mustGetUserHomeDir(), "directory to search for the configuration file")
 	isDryRun := cli.Bool("dry-run", false, "outputs instead of executing gh")
 

--- a/main_test.go
+++ b/main_test.go
@@ -317,6 +317,36 @@ func Test_run(t *testing.T) {
 		exit int
 	}{
 		{
+			name: "when help is requested",
+			args: args{
+				args:   []string{"--help"},
+				ghExec: expectNoCallToGh(t),
+				config: `
+					repositories:
+						octocat/hello-world:
+							default:
+								- octodog
+								- octopus
+				`,
+			},
+			exit: 0,
+		},
+		{
+			name: "when an unknown flag is requested",
+			args: args{
+				args:   []string{"--blah"},
+				ghExec: expectNoCallToGh(t),
+				config: `
+					repositories:
+						octocat/hello-world:
+							default:
+								- octodog
+								- octopus
+				`,
+			},
+			exit: 1,
+		},
+		{
 			name: "when no arguments are provided",
 			args: args{
 				args:   []string{},

--- a/main_test.go
+++ b/main_test.go
@@ -395,6 +395,24 @@ func Test_run(t *testing.T) {
 			exit: 0,
 		},
 		{
+			name: "when -R is provided",
+			args: args{
+				args:   []string{"-R", "octocat/hello-sunshine", "123"},
+				ghExec: expectCallToGh(t, "octocat/hello-sunshine", "123"),
+				config: `
+					repositories:
+						octocat/hello-world:
+							default:
+								- octocat
+						octocat/hello-sunshine:
+							default:
+								- octodog
+								- octopus
+				`,
+			},
+			exit: 0,
+		},
+		{
 			name: "when --repo is not prefixed with the owner",
 			args: args{
 				args:   []string{"--repo", "hello-world"},
@@ -491,6 +509,27 @@ func Test_run(t *testing.T) {
 			name: "explicit group",
 			args: args{
 				args:   []string{"--from", "infra", "123"},
+				ghExec: expectCallToGh(t, "octocat/hello-world", "123"),
+				config: `
+					repositories:
+						octocat/hello-world:
+							default:
+								- octocat
+							infra:
+								- octodog
+								- octopus
+						octocat/hello-sunshine:
+							default:
+								- octodog
+								- octopus
+				`,
+			},
+			exit: 0,
+		},
+		{
+			name: "when a group is provided (shorthand)",
+			args: args{
+				args:   []string{"-f", "infra", "123"},
 				ghExec: expectCallToGh(t, "octocat/hello-world", "123"),
 				config: `
 					repositories:


### PR DESCRIPTION
While it seems like `pflag` is not really maintained, it only adds ~100kb to the binary rather than the 1-2mb the other libraries would bring in, and works fine for this usage.

Resolves #14