### PR TITLE
test: make names more consistent and remove duplicate case

### DIFF
--- a/__snapshots__/main_test.snap
+++ b/__snapshots__/main_test.snap
@@ -1,17 +1,4 @@
 
-[Test_run/when_--repo_is_not_prefixed_with_the_owner - 1]
-
----
-
-[Test_run/when_--repo_is_not_prefixed_with_the_owner - 2]
-repository should be in the format of <owner>/<repository>
-
----
-
-[Test_run/when_--repo_is_not_prefixed_with_the_owner - 3]
-null
----
-
 [Test_run/when_an_explicit_group_is_provided_using_the_longhand_flag - 1]
 requested reviews on https://github.com/octocat/hello-world/pull/123 from:
   - octodog

--- a/__snapshots__/main_test.snap
+++ b/__snapshots__/main_test.snap
@@ -1,109 +1,4 @@
 
-[Test_run/config_does_not_exist - 1]
-
----
-
-[Test_run/config_does_not_exist - 2]
-please create <tempdir>/gh-rr.yml to configure your repositories
-
----
-
-[Test_run/config_does_not_exist - 3]
-null
----
-
-[Test_run/dry_run - 1]
-would have used `gh pr edit --repo octocat/hello-world` to request reviews from:
-  - octocat
-
----
-
-[Test_run/dry_run - 2]
-
----
-
-[Test_run/dry_run - 3]
-null
----
-
-[Test_run/explicit_group - 1]
-requested reviews on https://github.com/octocat/hello-world/pull/123 from:
-  - octodog
-  - octopus
-
----
-
-[Test_run/explicit_group - 2]
-
----
-
-[Test_run/explicit_group - 3]
-[
- "pr",
- "edit",
- "123",
- "--repo",
- "octocat/hello-world",
- "--add-reviewer",
- "octodog",
- "--add-reviewer",
- "octopus"
-]
----
-
-[Test_run/group_does_not_exist_in_config - 1]
-
----
-
-[Test_run/group_does_not_exist_in_config - 2]
-octocat/hello-world does not have a group named does-not-exist
-
----
-
-[Test_run/group_does_not_exist_in_config - 3]
-null
----
-
-[Test_run/invalid_config - 1]
-
----
-
-[Test_run/invalid_config - 2]
-yaml: unmarshal errors:
-  line 1: cannot unmarshal !!! `` into main.Config
-
----
-
-[Test_run/invalid_config - 3]
-null
----
-
-[Test_run/repository_does_not_exist_in_config - 1]
-
----
-
-[Test_run/repository_does_not_exist_in_config - 2]
-no reviewers are configured for octocat/hello-world
-
----
-
-[Test_run/repository_does_not_exist_in_config - 3]
-null
----
-
-[Test_run/when_--repo_is_a_url - 1]
-
----
-
-[Test_run/when_--repo_is_a_url - 2]
-repository should be in the format of <owner>/<repository>
-
----
-
-[Test_run/when_--repo_is_a_url - 3]
-null
----
-
 [Test_run/when_--repo_is_not_prefixed_with_the_owner - 1]
 
 ---
@@ -117,87 +12,99 @@ repository should be in the format of <owner>/<repository>
 null
 ---
 
-[Test_run/when_--repo_is_not_prefixed_with_the_owner#01 - 1]
-
----
-
-[Test_run/when_--repo_is_not_prefixed_with_the_owner#01 - 2]
-repository should be in the format of <owner>/<repository>
-
----
-
-[Test_run/when_--repo_is_not_prefixed_with_the_owner#01 - 3]
-null
----
-
-[Test_run/when_--repo_is_provided - 1]
-requested reviews on https://github.com/octocat/hello-sunshine/pull/123 from:
-  - octodog
-  - octopus
-
----
-
-[Test_run/when_--repo_is_provided - 2]
-
----
-
-[Test_run/when_--repo_is_provided - 3]
-[
- "pr",
- "edit",
- "123",
- "--repo",
- "octocat/hello-sunshine",
- "--add-reviewer",
- "octodog",
- "--add-reviewer",
- "octopus"
-]
----
-
-[Test_run/when_-R_is_provided - 1]
-requested reviews on https://github.com/octocat/hello-sunshine/pull/123 from:
-  - octodog
-  - octopus
-
----
-
-[Test_run/when_-R_is_provided - 2]
-
----
-
-[Test_run/when_-R_is_provided - 3]
-[
- "pr",
- "edit",
- "123",
- "--repo",
- "octocat/hello-sunshine",
- "--add-reviewer",
- "octodog",
- "--add-reviewer",
- "octopus"
-]
----
-
-[Test_run/when_a_group_is_provided_(shorthand) - 1]
+[Test_run/when_an_explicit_group_is_provided_using_the_longhand_flag - 1]
 requested reviews on https://github.com/octocat/hello-world/pull/123 from:
   - octodog
   - octopus
 
 ---
 
-[Test_run/when_a_group_is_provided_(shorthand) - 2]
+[Test_run/when_an_explicit_group_is_provided_using_the_longhand_flag - 2]
 
 ---
 
-[Test_run/when_a_group_is_provided_(shorthand) - 3]
+[Test_run/when_an_explicit_group_is_provided_using_the_longhand_flag - 3]
 [
  "pr",
  "edit",
  "123",
  "--repo",
  "octocat/hello-world",
+ "--add-reviewer",
+ "octodog",
+ "--add-reviewer",
+ "octopus"
+]
+---
+
+[Test_run/when_an_explicit_group_is_provided_using_the_shorthand_flag - 1]
+requested reviews on https://github.com/octocat/hello-world/pull/123 from:
+  - octodog
+  - octopus
+
+---
+
+[Test_run/when_an_explicit_group_is_provided_using_the_shorthand_flag - 2]
+
+---
+
+[Test_run/when_an_explicit_group_is_provided_using_the_shorthand_flag - 3]
+[
+ "pr",
+ "edit",
+ "123",
+ "--repo",
+ "octocat/hello-world",
+ "--add-reviewer",
+ "octodog",
+ "--add-reviewer",
+ "octopus"
+]
+---
+
+[Test_run/when_an_explicit_repository_is_provided_using_the_longhand_flag - 1]
+requested reviews on https://github.com/octocat/hello-sunshine/pull/123 from:
+  - octodog
+  - octopus
+
+---
+
+[Test_run/when_an_explicit_repository_is_provided_using_the_longhand_flag - 2]
+
+---
+
+[Test_run/when_an_explicit_repository_is_provided_using_the_longhand_flag - 3]
+[
+ "pr",
+ "edit",
+ "123",
+ "--repo",
+ "octocat/hello-sunshine",
+ "--add-reviewer",
+ "octodog",
+ "--add-reviewer",
+ "octopus"
+]
+---
+
+[Test_run/when_an_explicit_repository_is_provided_using_the_shorthand_flag - 1]
+requested reviews on https://github.com/octocat/hello-sunshine/pull/123 from:
+  - octodog
+  - octopus
+
+---
+
+[Test_run/when_an_explicit_repository_is_provided_using_the_shorthand_flag - 2]
+
+---
+
+[Test_run/when_an_explicit_repository_is_provided_using_the_shorthand_flag - 3]
+[
+ "pr",
+ "edit",
+ "123",
+ "--repo",
+ "octocat/hello-sunshine",
  "--add-reviewer",
  "octodog",
  "--add-reviewer",
@@ -215,6 +122,20 @@ unknown flag: --blah
 ---
 
 [Test_run/when_an_unknown_flag_is_requested - 3]
+null
+---
+
+[Test_run/when_doing_a_dry-run - 1]
+would have used `gh pr edit --repo octocat/hello-world` to request reviews from:
+  - octocat
+
+---
+
+[Test_run/when_doing_a_dry-run - 2]
+
+---
+
+[Test_run/when_doing_a_dry-run - 3]
 null
 ---
 
@@ -280,6 +201,85 @@ requested reviews on https://github.com/octocat/hello-world/pull/1 from:
  "--add-reviewer",
  "octopus"
 ]
+---
+
+[Test_run/when_the_config_file_does_not_exist - 1]
+
+---
+
+[Test_run/when_the_config_file_does_not_exist - 2]
+please create <tempdir>/gh-rr.yml to configure your repositories
+
+---
+
+[Test_run/when_the_config_file_does_not_exist - 3]
+null
+---
+
+[Test_run/when_the_config_file_is_invalid - 1]
+
+---
+
+[Test_run/when_the_config_file_is_invalid - 2]
+yaml: unmarshal errors:
+  line 1: cannot unmarshal !!! `` into main.Config
+
+---
+
+[Test_run/when_the_config_file_is_invalid - 3]
+null
+---
+
+[Test_run/when_the_explicit_repository_is_a_url - 1]
+
+---
+
+[Test_run/when_the_explicit_repository_is_a_url - 2]
+repository should be in the format of <owner>/<repository>
+
+---
+
+[Test_run/when_the_explicit_repository_is_a_url - 3]
+null
+---
+
+[Test_run/when_the_explicit_repository_is_not_prefixed_with_the_owner - 1]
+
+---
+
+[Test_run/when_the_explicit_repository_is_not_prefixed_with_the_owner - 2]
+repository should be in the format of <owner>/<repository>
+
+---
+
+[Test_run/when_the_explicit_repository_is_not_prefixed_with_the_owner - 3]
+null
+---
+
+[Test_run/when_the_group_does_not_exist_in_config - 1]
+
+---
+
+[Test_run/when_the_group_does_not_exist_in_config - 2]
+octocat/hello-world does not have a group named does-not-exist
+
+---
+
+[Test_run/when_the_group_does_not_exist_in_config - 3]
+null
+---
+
+[Test_run/when_the_repository_does_not_exist_in_config - 1]
+
+---
+
+[Test_run/when_the_repository_does_not_exist_in_config - 2]
+no reviewers are configured for octocat/hello-world
+
+---
+
+[Test_run/when_the_repository_does_not_exist_in_config - 3]
+null
 ---
 
 [Test_run/when_the_target_is_not_a_number - 1]

--- a/main_test.go
+++ b/main_test.go
@@ -134,15 +134,6 @@ func Test_run(t *testing.T) {
 			exit: 1,
 		},
 		{
-			name: "when --repo is not prefixed with the owner",
-			args: args{
-				args:   []string{"--repo", "hello-world"},
-				ghExec: expectNoCallToGh(t),
-				config: "",
-			},
-			exit: 1,
-		},
-		{
 			name: "when the explicit repository is a url",
 			args: args{
 				args:   []string{"--repo", "https://github.com/octocat/hello-world"},

--- a/main_test.go
+++ b/main_test.go
@@ -89,7 +89,7 @@ func Test_run(t *testing.T) {
 			exit: 0,
 		},
 		{
-			name: "when --repo is provided",
+			name: "when an explicit repository is provided using the longhand flag",
 			args: args{
 				args:   []string{"--repo", "octocat/hello-sunshine", "123"},
 				ghExec: expectCallToGh(t, "octocat/hello-sunshine", "123"),
@@ -107,7 +107,7 @@ func Test_run(t *testing.T) {
 			exit: 0,
 		},
 		{
-			name: "when -R is provided",
+			name: "when an explicit repository is provided using the shorthand flag",
 			args: args{
 				args:   []string{"-R", "octocat/hello-sunshine", "123"},
 				ghExec: expectCallToGh(t, "octocat/hello-sunshine", "123"),
@@ -125,7 +125,7 @@ func Test_run(t *testing.T) {
 			exit: 0,
 		},
 		{
-			name: "when --repo is not prefixed with the owner",
+			name: "when the explicit repository is not prefixed with the owner",
 			args: args{
 				args:   []string{"--repo", "hello-world"},
 				ghExec: expectNoCallToGh(t),
@@ -143,7 +143,7 @@ func Test_run(t *testing.T) {
 			exit: 1,
 		},
 		{
-			name: "when --repo is a url",
+			name: "when the explicit repository is a url",
 			args: args{
 				args:   []string{"--repo", "https://github.com/octocat/hello-world"},
 				ghExec: expectNoCallToGh(t),
@@ -152,7 +152,7 @@ func Test_run(t *testing.T) {
 			exit: 1,
 		},
 		{
-			name: "config does not exist",
+			name: "when the config file does not exist",
 			args: args{
 				args:   []string{"123"},
 				ghExec: expectNoCallToGh(t),
@@ -161,7 +161,7 @@ func Test_run(t *testing.T) {
 			exit: 1,
 		},
 		{
-			name: "invalid config",
+			name: "when the config file is invalid",
 			args: args{
 				args:   []string{"123"},
 				ghExec: expectNoCallToGh(t),
@@ -170,7 +170,7 @@ func Test_run(t *testing.T) {
 			exit: 1,
 		},
 		{
-			name: "repository does not exist in config",
+			name: "when the repository does not exist in config",
 			args: args{
 				args:   []string{"123"},
 				ghExec: expectNoCallToGh(t),
@@ -185,7 +185,7 @@ func Test_run(t *testing.T) {
 			exit: 1,
 		},
 		{
-			name: "group does not exist in config",
+			name: "when the group does not exist in config",
 			args: args{
 				args:   []string{"--from", "does-not-exist", "123"},
 				ghExec: expectNoCallToGh(t),
@@ -200,7 +200,7 @@ func Test_run(t *testing.T) {
 			exit: 1,
 		},
 		{
-			name: "dry run",
+			name: "when doing a dry-run",
 			args: args{
 				args:   []string{"--dry-run", "123"},
 				ghExec: expectNoCallToGh(t),
@@ -218,7 +218,7 @@ func Test_run(t *testing.T) {
 			exit: 0,
 		},
 		{
-			name: "explicit group",
+			name: "when an explicit group is provided using the longhand flag",
 			args: args{
 				args:   []string{"--from", "infra", "123"},
 				ghExec: expectCallToGh(t, "octocat/hello-world", "123"),
@@ -239,7 +239,7 @@ func Test_run(t *testing.T) {
 			exit: 0,
 		},
 		{
-			name: "when a group is provided (shorthand)",
+			name: "when an explicit group is provided using the shorthand flag",
 			args: args{
 				args:   []string{"-f", "infra", "123"},
 				ghExec: expectCallToGh(t, "octocat/hello-world", "123"),


### PR DESCRIPTION
This makes test names more consistent, based around the idea of the name describing the situation and that the test expresses the outcome