### PR TITLE
feat: support omitting `default` group map

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,17 @@ repositories:
     security:
       - octopus
   g-rath/my-awesome-app:
+    # this is the implicit default group that will be used for this repository
+    - g-rath
+    - octocat
+  g-rath/my-awesome-api:
     # this is the default group that will be used for this repository
     default:
       - g-rath
-      - octocat
     # this is an alternative group for this repository, which can be selected with -f|--from
     infra:
       - octodog
       - octopus
-  g-rath/dotfiles:
-    # this is the default group that will be used for this repository
-    default:
-      - g-rath
 ```
 
 Then start requesting reviewers on your pull requests:

--- a/__snapshots__/main_test.snap
+++ b/__snapshots__/main_test.snap
@@ -1,4 +1,18 @@
 
+[Test_run/when_an_array_is_provided_instead_of_a_map_of_groups - 1]
+
+---
+
+[Test_run/when_an_array_is_provided_instead_of_a_map_of_groups - 2]
+yaml: unmarshal errors:
+  line 3: cannot unmarshal !!seq into map[string][]string
+
+---
+
+[Test_run/when_an_array_is_provided_instead_of_a_map_of_groups - 3]
+null
+---
+
 [Test_run/when_an_explicit_group_is_provided_using_the_longhand_flag - 1]
 requested reviews on https://github.com/octocat/hello-world/pull/123 from:
   - octodog

--- a/__snapshots__/main_test.snap
+++ b/__snapshots__/main_test.snap
@@ -1,16 +1,27 @@
 
 [Test_run/when_an_array_is_provided_instead_of_a_map_of_groups - 1]
+requested reviews on https://github.com/octocat/hello-world/pull/1 from:
+  - octodog
+  - octopus
 
 ---
 
 [Test_run/when_an_array_is_provided_instead_of_a_map_of_groups - 2]
-yaml: unmarshal errors:
-  line 3: cannot unmarshal !!seq into map[string][]string
 
 ---
 
 [Test_run/when_an_array_is_provided_instead_of_a_map_of_groups - 3]
-null
+[
+ "pr",
+ "edit",
+ "",
+ "--repo",
+ "octocat/hello-world",
+ "--add-reviewer",
+ "octodog",
+ "--add-reviewer",
+ "octopus"
+]
 ---
 
 [Test_run/when_an_explicit_group_is_provided_using_the_longhand_flag - 1]
@@ -263,7 +274,7 @@ null
 
 [Test_run/when_the_config_file_is_invalid_(in_a_different_way) - 2]
 yaml: unmarshal errors:
-  line 1: cannot unmarshal !!int `1` into map[string]map[string][]string
+  line 1: cannot unmarshal !!int `1` into map[string]main.repositoryGroups
 
 ---
 

--- a/main_test.go
+++ b/main_test.go
@@ -200,6 +200,20 @@ func Test_run(t *testing.T) {
 			exit: 1,
 		},
 		{
+			name: "when an array is provided instead of a map of groups",
+			args: args{
+				args:   []string{},
+				ghExec: expectCallToGh(t, "octocat/hello-world", "1"),
+				config: `
+					repositories:
+						octocat/hello-world:
+							- octodog
+							- octopus
+				`,
+			},
+			exit: 1,
+		},
+		{
 			name: "when doing a dry-run",
 			args: args{
 				args:   []string{"--dry-run", "123"},

--- a/main_test.go
+++ b/main_test.go
@@ -211,7 +211,7 @@ func Test_run(t *testing.T) {
 							- octopus
 				`,
 			},
-			exit: 1,
+			exit: 0,
 		},
 		{
 			name: "when doing a dry-run",


### PR DESCRIPTION
This allows you to omit the second layer of mapping for repositories when you only want a `default` group of reviewers by attempting to parse the node as an array first before then parsing it as a map.

I'm on the fence about landing it as while it seems like a cool little extra, the code is a little annoying (I really wish I didn't have to have the named inner type), but tbh its probably fine...

Resolves #13