### PR TITLE
feat: support "global" reviewer groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,22 @@ reviewers:
 ```yaml
 # this is a map of repositories to groups of GitHub usernames
 repositories:
+  # these are "global" groups, which can be enabled with -g|--global
+  '*':
+    bob: [octopus]
+    security:
+      - octopus
   g-rath/my-awesome-app:
+    # this is the default group that will be used for this repository
     default:
       - g-rath
       - octocat
+    # this is an alternative group for this repository, which can be selected with -f|--from
     infra:
       - octodog
       - octopus
   g-rath/dotfiles:
+    # this is the default group that will be used for this repository
     default:
       - g-rath
 ```
@@ -55,6 +63,17 @@ You can also use the `-f|--from` flag to target alternative reviewer groups:
 
 ```shell
 gh rr --from infra
+```
+
+This can be combined with the `-g|--global` to target "global" groups which are
+defined under the `*` repository:
+
+```shell
+# makes it easy to add a specific person
+gh rr -gf bob
+
+# or target a group of common people
+gh rr -gf security
 ```
 
 ## Why not use [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) or [GitHub teams](https://docs.github.com/en/organizations/organizing-members-into-teams/managing-code-review-settings-for-your-team)?

--- a/__snapshots__/main_test.snap
+++ b/__snapshots__/main_test.snap
@@ -157,6 +157,7 @@ Usage of gh rr:
       --config-dir string   directory to search for the configuration file (default "<homedir>")
       --dry-run             outputs instead of executing gh
   -f, --from string         group of users to request review from (default "default")
+  -g, --global              use the global reviewer groups
   -R, --repo string         select another repository using the [HOST/]OWNER/REPO format
 
 ---
@@ -330,6 +331,129 @@ requested reviews on https://github.com/octocat/hello-world/pull/abc from:
  "octodog",
  "--add-reviewer",
  "octopus"
+]
+---
+
+[Test_run_GlobalGroups/when_a_specific_repository_is_given_that_is_not_in_the_config - 1]
+requested reviews on https://github.com/octocat/hello-sunshine/pull/1 from:
+  - octodog
+
+---
+
+[Test_run_GlobalGroups/when_a_specific_repository_is_given_that_is_not_in_the_config - 2]
+
+---
+
+[Test_run_GlobalGroups/when_a_specific_repository_is_given_that_is_not_in_the_config - 3]
+[
+ "pr",
+ "edit",
+ "",
+ "--repo",
+ "octocat/hello-sunshine",
+ "--add-reviewer",
+ "octodog"
+]
+---
+
+[Test_run_GlobalGroups/when_combining_shorthand_flags - 1]
+requested reviews on https://github.com/octocat/hello-world/pull/1 from:
+  - octodog
+
+---
+
+[Test_run_GlobalGroups/when_combining_shorthand_flags - 2]
+
+---
+
+[Test_run_GlobalGroups/when_combining_shorthand_flags - 3]
+[
+ "pr",
+ "edit",
+ "",
+ "--repo",
+ "octocat/hello-world",
+ "--add-reviewer",
+ "octodog"
+]
+---
+
+[Test_run_GlobalGroups/when_the_repo_has_a_group_with_the_same_name - 1]
+requested reviews on https://github.com/octocat/hello-world/pull/1 from:
+  - octodog
+
+---
+
+[Test_run_GlobalGroups/when_the_repo_has_a_group_with_the_same_name - 2]
+
+---
+
+[Test_run_GlobalGroups/when_the_repo_has_a_group_with_the_same_name - 3]
+[
+ "pr",
+ "edit",
+ "",
+ "--repo",
+ "octocat/hello-world",
+ "--add-reviewer",
+ "octodog"
+]
+---
+
+[Test_run_GlobalGroups/when_the_repo_has_a_group_with_the_same_name_but_the_global_one_does_not_exist - 1]
+
+---
+
+[Test_run_GlobalGroups/when_the_repo_has_a_group_with_the_same_name_but_the_global_one_does_not_exist - 2]
+octocat/hello-world does not have a group named security
+
+---
+
+[Test_run_GlobalGroups/when_the_repo_has_a_group_with_the_same_name_but_the_global_one_does_not_exist - 3]
+null
+---
+
+[Test_run_GlobalGroups/when_using_the_longhand_flag - 1]
+requested reviews on https://github.com/octocat/hello-world/pull/1 from:
+  - octodog
+
+---
+
+[Test_run_GlobalGroups/when_using_the_longhand_flag - 2]
+
+---
+
+[Test_run_GlobalGroups/when_using_the_longhand_flag - 3]
+[
+ "pr",
+ "edit",
+ "",
+ "--repo",
+ "octocat/hello-world",
+ "--add-reviewer",
+ "octodog"
+]
+---
+
+[Test_run_GlobalGroups/when_using_the_shorthand_flag - 1]
+requested reviews on https://github.com/octocat/hello-world/pull/1 from:
+  - octodog
+
+---
+
+[Test_run_GlobalGroups/when_using_the_shorthand_flag - 2]
+
+---
+
+[Test_run_GlobalGroups/when_using_the_shorthand_flag - 3]
+[
+ "pr",
+ "edit",
+ "",
+ "--repo",
+ "octocat/hello-world",
+ "--add-reviewer",
+ "octodog"
 ]
 ---
 

--- a/main.go
+++ b/main.go
@@ -100,6 +100,7 @@ func run(args []string, stdout, stderr io.Writer, ghExec ghExecutor) int {
 
 	repoF := cli.StringP("repo", "R", "", "select another repository using the [HOST/]OWNER/REPO format")
 	group := cli.StringP("from", "f", "default", "group of users to request review from")
+	globalGroups := cli.BoolP("global", "g", false, "use the global reviewer groups")
 	configDir := cli.String("config-dir", mustGetUserHomeDir(), "directory to search for the configuration file")
 	isDryRun := cli.Bool("dry-run", false, "outputs instead of executing gh")
 
@@ -153,7 +154,12 @@ func run(args []string, stdout, stderr io.Writer, ghExec ghExecutor) int {
 		return 1
 	}
 
-	reviewers, err := determineReviewers(conf, strings.ToLower(repo), *group)
+	repo2 := repo
+
+	if *globalGroups {
+		repo2 = "*"
+	}
+	reviewers, err := determineReviewers(conf, strings.ToLower(repo2), *group)
 
 	if err != nil {
 		if errors.Is(err, errRepositoryNotConfigured) {


### PR DESCRIPTION
This adds support for a "global" repository which is represented by a `*` (which can never be a real repository, so there's no chance of conflict) and can be particularly nice for mapping people to their GitHub usernames.

Of course now this has me considering supporting an array of `-f|--from` so I can do `gh rr -gf bob,alice,frank` 🤔 

Resolves #3