### PR TITLE
chore: pin Go specifically to v1.21.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/g-rath/gh-rr
 
-go 1.21
+go 1.21.9
 
 require (
 	github.com/cli/go-gh/v2 v2.8.0


### PR DESCRIPTION
CodeQL claims that v1.21+ requires the full version to be specified - previously this broke `cli/gh-extension-precompile` which I suspect will happen again, but if so I'll tackle that another way